### PR TITLE
BT central legacy OOB only warnings

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3640,6 +3640,7 @@ static uint8_t sc_smp_check_confirm(struct bt_smp *smp)
 	return 0;
 }
 
+#ifndef CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY
 static bool le_sc_oob_data_req_check(struct bt_smp *smp)
 {
 	struct bt_smp_pairing *req = (struct bt_smp_pairing *)&smp->preq[1];
@@ -3684,6 +3685,7 @@ static void le_sc_oob_config_set(struct bt_smp *smp,
 
 	info->lesc.oob_config = oob_config;
 }
+#endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 static uint8_t smp_pairing_random(struct bt_smp *smp, struct net_buf *buf)
 {
@@ -3798,8 +3800,7 @@ static uint8_t smp_pairing_random(struct bt_smp *smp, struct net_buf *buf)
 			return BT_SMP_ERR_UNSPECIFIED;
 		}
 
-		if (!IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) && smp_auth_cb &&
-		    smp_auth_cb->oob_data_request) {
+		if (smp_auth_cb && smp_auth_cb->oob_data_request) {
 			struct bt_conn_oob_info info = {
 				.type = BT_CONN_OOB_LE_SC,
 				.lesc.oob_config = BT_CONN_OOB_NO_DATA,
@@ -4184,6 +4185,7 @@ static uint8_t smp_security_request(struct bt_smp *smp, struct net_buf *buf)
 }
 #endif /* CONFIG_BT_CENTRAL */
 
+#ifndef CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY
 static uint8_t generate_dhkey(struct bt_smp *smp)
 {
 	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
@@ -4225,6 +4227,7 @@ static uint8_t display_passkey(struct bt_smp *smp)
 
 	return 0;
 }
+#endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 #if defined(CONFIG_BT_PERIPHERAL)
 static uint8_t smp_public_key_periph(struct bt_smp *smp)

--- a/tests/bluetooth/host_config_variants/testcase.yaml
+++ b/tests/bluetooth/host_config_variants/testcase.yaml
@@ -1,9 +1,27 @@
 tests:
   # Test that the Host builds with BT_SMP_OOB_LEGACY_PAIR_ONLY enabled
-  bluetooth.host_config_variants.config_bt_smp_oob_legacy_pair_only:
+  # and peripheral role
+  bluetooth.host_config_variants.config_peripheral_bt_smp_oob_legacy_pair_only:
     extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PERIPHERAL=y
+      - CONFIG_BT_SMP_SC_PAIR_ONLY=n
+      - CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+    tags:
+      - bluetooth
+    build_only: true
+
+  # Test that the Host builds with BT_SMP_OOB_LEGACY_PAIR_ONLY enabled
+  # and central role
+  bluetooth.host_config_variants.config_central_bt_smp_oob_legacy_pair_only:
+    extra_configs:
+      - CONFIG_BT_SMP=y
+      - CONFIG_BT_CENTRAL=y
       - CONFIG_BT_SMP_SC_PAIR_ONLY=n
       - CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY=y
     platform_allow:


### PR DESCRIPTION
Currently, there are build warnings that are triggered when building
for BT central and legacy OOB pairing only:
CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY=y
CONFIG_BT_CENTRAL=y

There was a PR that handled this issue in the past https://github.com/zephyrproject-rtos/zephyr/pull/74400.
Unfortunately, this PR even though it fixed the warnings it also
broke the BT peripheral and legacy OOB pairing only build:
CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY=y
CONFIG_BT_PERIPHERAL=y

https://github.com/zephyrproject-rtos/zephyr/pull/82552 was merged in
order to fix the issue with the peripheral build configuration.
Unfortunately, this PR reintroduced the warnings for BT central and
legacy OOB pairing.

This commit brings changes to make sure that both the BT central and
peripheral builds with OOB legacy pairing are buildable and
warnings free.

Also in this commit, a new build test case is added for the BT central
and legacy OOB pairing along the existing BT peripheral test case